### PR TITLE
Update Dockerfile to fix trailets error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN git clone https://github.com/salesforce/BLIP /content/BLIP
 RUN git clone https://github.com/pengbo-learn/python-color-transfer /content/python-color-transfer
 RUN git clone https://github.com/Stability-AI/generative-models /content/generative-models
 RUN git clone https://github.com/comfyanonymous/ComfyUI ComfyUI
-RUN python -m pip install entrypoints==0.4 ipython==8.10.0 jupyter_client==7.4.9 jupyter_core==5.2.0 packaging==22.0 tzdata==2022.7 ipykernel --force-reinstall
+RUN python -m pip install entrypoints==0.4 ipython==8.10.0 jupyter_client==7.4.9 jupyter_core==5.2.0 packaging==22.0 tzdata==2022.7 traitlets==5.9.0  ipykernel --force-reinstall
 RUN python -m ipykernel install --user && python -m pip install --upgrade jupyter_http_over_ws>=0.0.7 && jupyter serverextension enable --py jupyter_http_over_ws
 
 RUN ln -s /usr/local/lib/python3.10/dist-packages/torch/lib/libnvrtc-672ee683.so.11.2 /usr/local/lib/python3.10/dist-packages/torch/lib/libnvrtc.so 


### PR DESCRIPTION
Without this fix, you get the following error:

```
docker-warpfusion-1  | Traceback (most recent call last):
docker-warpfusion-1  |   File "/usr/lib/python3/dist-packages/notebook/traittypes.py", line 232, in _resolve_classes
docker-warpfusion-1  |     klass = self._resolve_string(klass)
docker-warpfusion-1  |   File "/usr/local/lib/python3.10/dist-packages/traitlets/traitlets.py", line 2025, in _resolve_string
docker-warpfusion-1  |     return import_item(string)
docker-warpfusion-1  |   File "/usr/local/lib/python3.10/dist-packages/traitlets/utils/importstring.py", line 31, in import_item
docker-warpfusion-1  |     module = __import__(package, fromlist=[obj])
docker-warpfusion-1  | ModuleNotFoundError: No module named 'jupyter_server'
docker-warpfusion-1  |
docker-warpfusion-1  | During handling of the above exception, another exception occurred:
docker-warpfusion-1  |
docker-warpfusion-1  | Traceback (most recent call last):
docker-warpfusion-1  |   File "/usr/bin/jupyter-notebook", line 33, in <module>
docker-warpfusion-1  |     sys.exit(load_entry_point('notebook==6.4.8', 'console_scripts', 'jupyter-notebook')())
docker-warpfusion-1  |   File "/usr/local/lib/python3.10/dist-packages/jupyter_core/application.py", line 277, in launch_instance
docker-warpfusion-1  |     return super().launch_instance(argv=argv, **kwargs)
docker-warpfusion-1  |   File "/usr/local/lib/python3.10/dist-packages/traitlets/config/application.py", line 1051, in launch_instance
docker-warpfusion-1  |     app = cls.instance(**kwargs)
docker-warpfusion-1  |   File "/usr/local/lib/python3.10/dist-packages/traitlets/config/configurable.py", line 575, in instance
docker-warpfusion-1  |     inst = cls(*args, **kwargs)
docker-warpfusion-1  |   File "/usr/local/lib/python3.10/dist-packages/traitlets/traitlets.py", line 1311, in __new__
docker-warpfusion-1  |     inst.setup_instance(*args, **kwargs)
docker-warpfusion-1  |   File "/usr/local/lib/python3.10/dist-packages/traitlets/traitlets.py", line 1354, in setup_instance
docker-warpfusion-1  |     super(HasTraits, self).setup_instance(*args, **kwargs)
docker-warpfusion-1  |   File "/usr/local/lib/python3.10/dist-packages/traitlets/traitlets.py", line 1330, in setup_instance
docker-warpfusion-1  |     init(self)
docker-warpfusion-1  |   File "/usr/lib/python3/dist-packages/notebook/traittypes.py", line 223, in instance_init
docker-warpfusion-1  |     self._resolve_classes()
docker-warpfusion-1  |   File "/usr/lib/python3/dist-packages/notebook/traittypes.py", line 235, in _resolve_classes
docker-warpfusion-1  |     warn(f"{klass} is not importable. Is it installed?", ImportWarning)
docker-warpfusion-1  | TypeError: warn() missing 1 required keyword-only argument: 'stacklevel'
docker-warpfusion-1 exited with code 1
```

I found this fix on:
https://github.com/microsoft/azuredatastudio/issues/24436